### PR TITLE
Fix Resonite path handling

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ runs:
       shell: pwsh
       run: |
         $resonitePath = "${{ inputs.resonite-path }}"
+        if ($resonitePath[-1] -ne [IO.Path]::DirectorySeparatorChar) {
+          $resonitePath += [IO.Path]::DirectorySeparatorChar
+        }
         $librariesPath = Join-Path $resonitePath "Libraries"
         $rmlLibsPath = Join-Path $resonitePath "rml_libs"
 


### PR DESCRIPTION
## Summary
- revert bundling TestProject and restore remote checkout in CI
- ensure trailing directory separator for `resonite-path` output

## Testing
- `dotnet --version`
- `git status --short`
