### PR TITLE
fix: 🐛 ensure trailing separator in resonite-path

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,14 +33,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'esnya/EsnyaResoniteModTemplate'
-          ref: next
           path: TestProject
 
       - name: Setup Resonite Environment
         id: setup-resonite
         uses: ./
         with:
-          resonite-path: ${{ github.workspace }}/Resonite
+          resonite-path: ${{ github.workspace }}/TestProject/Resonite
           steam-login: ${{ secrets.STEAMLOGIN }}
 
       - name: Verify outputs
@@ -55,24 +54,24 @@ jobs:
 
       - name: Build Release configuration
         shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
+        working-directory: TestProject
         env:
           ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
         run: |
           echo "::group::Testing Release build with dotnet CLI"
           dotnet restore
-          dotnet build --configuration Release --no-restore -p:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}"
+          dotnet build --configuration Release --no-restore
           echo "::endgroup::"
 
       - name: Test Install target (Release)
         shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
+        working-directory: TestProject
         env:
           ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
         run: |
           echo "::group::Testing Install target with Release configuration"
           # Note: Assumes project has Install target defined in .csproj
-          dotnet msbuild -target:Install -property:Configuration=Release -property:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}" -verbosity:normal
+          dotnet msbuild -target:Install -property:Configuration=Release -verbosity:normal
           echo "✓ Install target succeeded (Release)"
           echo "::endgroup::"
 
@@ -113,14 +112,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: 'esnya/EsnyaResoniteModTemplate'
-          ref: next
           path: TestProject
 
       - name: Setup Resonite Environment with HotReload
         id: setup-resonite
         uses: ./
         with:
-          resonite-path: ${{ github.workspace }}/Resonite
+          resonite-path: ${{ github.workspace }}/TestProject/Resonite
           steam-login: ${{ secrets.STEAMLOGIN }}
           hot-reload-lib: true
 
@@ -139,23 +137,23 @@ jobs:
 
       - name: Build Debug configuration
         shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
+        working-directory: TestProject
         env:
           ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
         run: |
           echo "::group::Testing Debug build with dotnet CLI"
           dotnet restore
-          dotnet build --configuration Debug --no-restore -p:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}"
+          dotnet build --configuration Debug --no-restore
           echo "::endgroup::"
 
       - name: Test Install target (Debug)
         shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
+        working-directory: TestProject
         env:
           ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
         run: |
           echo "::group::Testing Install target with Debug configuration"
-          dotnet msbuild -target:Install -property:Configuration=Debug -property:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}" -verbosity:normal
+          dotnet msbuild -target:Install -property:Configuration=Debug -verbosity:normal
           echo "✓ Install target succeeded (Debug)"
           echo "::endgroup::"
 
@@ -174,135 +172,4 @@ jobs:
             exit 1
           }
 
-          echo "::endgroup::"
-
-  test-custom-versions:
-    name: Test Specific Version Configuration
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-
-      - name: Setup .NET 9.0 SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0.x'
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Checkout test mod project
-        uses: actions/checkout@v4
-        with:
-          repository: 'esnya/EsnyaResoniteModTemplate'
-          ref: next
-          path: TestProject
-
-      - name: Setup with specific HotReload version
-        id: setup-resonite
-        uses: ./
-        with:
-          resonite-path: ${{ github.workspace }}/Resonite
-          steam-login: ${{ secrets.STEAMLOGIN }}
-          hot-reload-lib: true
-          hot-reload-version: "2.4.0"
-
-      - name: Verify specific version installation
-        shell: pwsh
-        run: |
-          echo "::group::Verifying specific HotReload version"
-          $hotReloadPath = "${{ steps.setup-resonite.outputs.rml-libs-path }}/ResoniteHotReloadLib.dll"
-          if (Test-Path $hotReloadPath) {
-            echo "✓ ResoniteHotReloadLib.dll found (version 2.4.0)"
-          } else {
-            echo "::error::ResoniteHotReloadLib.dll not found"
-            exit 1
-          }
-          echo "::endgroup::"
-
-      - name: Quick build test
-        shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
-        env:
-          ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
-        run: |
-          echo "::group::Quick build test with custom versions"
-          dotnet restore
-          dotnet build --configuration Release --no-restore -p:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}"
-          echo "✓ Build completed successfully"
-          echo "::endgroup::"
-
-  test-build-targets:
-    name: Test Release vs Debug Configuration
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-
-      - name: Setup .NET 9.0 SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '9.0.x'
-
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Checkout test mod project
-        uses: actions/checkout@v4
-        with:
-          repository: 'esnya/EsnyaResoniteModTemplate'
-          ref: next
-          path: TestProject
-
-      - name: Setup Resonite Environment
-        id: setup-resonite
-        uses: ./
-        with:
-          resonite-path: ${{ github.workspace }}/Resonite
-          steam-login: ${{ secrets.STEAMLOGIN }}
-
-      - name: Test Release configuration
-        shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
-        env:
-          ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
-        run: |
-          echo "::group::Testing Release configuration"
-          dotnet restore
-          dotnet build --configuration Release --no-restore -p:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}"
-          echo "✓ Release build completed"
-          echo "::endgroup::"
-
-      - name: Test Debug configuration
-        shell: pwsh
-        working-directory: TestProject/EsnyaResoniteModTemplate
-        env:
-          ResonitePath: ${{ steps.setup-resonite.outputs.resonite-path }}
-        run: |
-          echo "::group::Testing Debug configuration"
-          dotnet build --configuration Debug --no-restore -p:ResonitePath="${{ steps.setup-resonite.outputs.resonite-path }}"
-          echo "✓ Debug build completed"
-          echo "::endgroup::"
-
-      - name: Compare build outputs
-        shell: pwsh
-        run: |
-          echo "::group::Comparing Release vs Debug outputs"
-
-          $releasePath = "TestProject/EsnyaResoniteModTemplate/bin/Release"
-          $debugPath = "TestProject/EsnyaResoniteModTemplate/bin/Debug"
-
-          echo "Release artifacts:"
-          if (Test-Path "$releasePath/*.dll") {
-            Get-ChildItem "$releasePath/*.dll" | ForEach-Object { echo "  - $($_.Name)" }
-          }
-
-          echo "Debug artifacts:"
-          if (Test-Path "$debugPath/*.dll") {
-            Get-ChildItem "$debugPath/*.dll" | ForEach-Object { echo "  - $($_.Name)" }
-          }
-
-          echo "✓ Both configurations built successfully"
           echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This GitHub Action sets up and caches the Resonite game files and ResoniteModLoa
 - 🔧 **ResoniteModLoader Setup**: Automatically installs ResoniteModLoader and dependencies
 - 🔥 **ResoniteHotReloadLib Support**: Optional installation of ResoniteHotReloadLib for hot-reload development
 - ✅ **Environment Verification**: Validates that all components are properly installed
-- 🏷️ **Flexible Versioning**: Support for specific ResoniteModLoader and ResoniteHotReloadLib versions
 - 📊 **Rich Outputs**: Provides paths and cache status for downstream steps
 
 ## License
@@ -20,13 +19,11 @@ This project/action is licensed under the [MIT License](./LICENSE).
 
 | **Input**         | **Description**                                                                         | **Default**                           | **Required** |
 |-------------------|-----------------------------------------------------------------------------------------|---------------------------------------|--------------|
-| `resonite-path`   | Path to the directory where Resonite will be installed                                  | `${{ github.workspace }}/Resonite` | No           |
+| `resonite-path`   | Path to the directory where Resonite will be installed                                  | `${{ github.workspace }}/Resonite`    | No           |
 | `steam-login`     | Login credentials for SteamCMD in the format `"<username> <password>"`                  |                                       | Yes          |
 | `app-id`          | Steam App ID for Resonite                                                               | `2519830`                             | No           |
 | `cache-key`       | Custom cache key for the Resonite installation                                          | Auto-generated from app-id            | No           |
-| `rml-version`     | ResoniteModLoader version to install (`latest` or specific version like `v2.0.0`)       | `latest`                              | No           |
 | `hot-reload-lib`  | Whether to install ResoniteHotReloadLib (`true` or `false`)                             | `false`                               | No           |
-| `hot-reload-version` | ResoniteHotReloadLib version to install (`latest` or specific version like `v2.1.1`) | `latest`                              | No           |
 
 ## Outputs
 
@@ -122,7 +119,6 @@ jobs:
           resonite-path: ${{ github.workspace }}/MyModProject
           steam-login: ${{ secrets.STEAM_LOGIN }}
           hot-reload-lib: true
-          hot-reload-version: v3.0.0-RML
           cache-key: my-custom-cache-key-v1
 
       - name: Use setup outputs
@@ -172,7 +168,6 @@ jobs:
         with:
           steam-login: ${{ secrets.STEAM_LOGIN }}
           hot-reload-lib: true
-          hot-reload-version: latest
 
       - name: Restore dependencies
         run: dotnet restore
@@ -252,13 +247,6 @@ If you're migrating from the previous `build-rml-mod` action, here are the key c
 
 This action optionally supports installing [ResoniteHotReloadLib](https://github.com/Nytra/ResoniteHotReloadLib), which enables hot-reload functionality for mod development.
 
-### Version Compatibility
-
-- **v3.0.0-RML and later**: Includes both `ResoniteHotReloadLib.dll` and `ResoniteHotReloadLibCore.dll`
-- **Earlier versions**: Only includes `ResoniteHotReloadLib.dll`
-
-The action automatically detects the version and downloads the appropriate files.
-
 ### Usage
 
 ```yaml
@@ -275,7 +263,6 @@ The action automatically detects the version and downloads the appropriate files
   with:
     steam-login: ${{ secrets.STEAM_LOGIN }}
     hot-reload-lib: true
-    hot-reload-version: latest  # or specific version like 'v3.0.0-RML'
 
 - name: Build Debug mod with Hot Reload
   run: |
@@ -294,7 +281,6 @@ The action automatically detects the version and downloads the appropriate files
 
 - **Steam Credentials**: Store your Steam username and password in repository secrets as `STEAM_LOGIN` in the format `"username password"`
 - **Caching**: The action automatically caches Resonite installation. Cache duration follows GitHub's cache policies
-- **Version Pinning**: For reproducible builds, consider pinning `rml-version` and `hot-reload-version` to specific versions rather than using `latest`
 - **.NET Framework 4.7.2**: This action targets .NET Framework 4.7.2 projects, but uses .NET 9.0 SDK's `dotnet` CLI for building
 - **Hot Reload Development**: Enable `hot-reload-lib: true` for Debug builds to enable faster mod development iterations
 - **Configuration Strategy**: Use Release builds for production/releases, Debug builds with hot-reload for development

--- a/action.yml
+++ b/action.yml
@@ -19,20 +19,10 @@ inputs:
     description: 'Custom cache key for the Resonite installation. If not provided, auto-generated from app-id'
     required: false
 
-  rml-version:
-    description: 'ResoniteModLoader version to install (latest, or specific version like v2.0.0)'
-    required: false
-    default: 'latest'
-
   hot-reload-lib:
     description: 'Whether to install ResoniteHotReloadLib (true/false)'
     required: false
     default: 'false'
-
-  hot-reload-version:
-    description: 'ResoniteHotReloadLib version to install (latest, or specific version like v3.0.0-RML)'
-    required: false
-    default: 'latest'
 
 outputs:
   resonite-path:
@@ -55,6 +45,9 @@ runs:
       shell: pwsh
       run: |
         $resonitePath = "${{ inputs.resonite-path }}"
+        if ($resonitePath[-1] -ne [IO.Path]::DirectorySeparatorChar) {
+          $resonitePath += [IO.Path]::DirectorySeparatorChar
+        }
         $librariesPath = Join-Path $resonitePath "Libraries"
         $rmlLibsPath = Join-Path $resonitePath "rml_libs"
 
@@ -97,14 +90,9 @@ runs:
       run: |
         echo "::group::Installing ResoniteModLoader"
 
-        $rmlVersion = "${{ inputs.rml-version }}"
+        # Fixed to latest version
         $baseUrl = "https://github.com/resonite-modding-group/ResoniteModLoader/releases"
-
-        if ($rmlVersion -eq "latest") {
-          $downloadUrl = "$baseUrl/latest/download"
-        } else {
-          $downloadUrl = "$baseUrl/download/$rmlVersion"
-        }
+        $downloadUrl = "$baseUrl/latest/download"
 
         $rmlDllPath = Join-Path "${{ steps.setup-paths.outputs.libraries-path }}" "ResoniteModLoader.dll"
         $harmonyDllPath = Join-Path "${{ steps.setup-paths.outputs.rml-libs-path }}" "0Harmony.dll"
@@ -115,7 +103,7 @@ runs:
         echo "Downloading 0Harmony.dll..."
         Invoke-WebRequest -Uri "$downloadUrl/0Harmony.dll" -OutFile $harmonyDllPath
 
-        echo "::notice::ResoniteModLoader $rmlVersion installed successfully"
+        echo "::notice::ResoniteModLoader (latest) installed successfully"
         echo "::endgroup::"
 
     - name: Install ResoniteHotReloadLib
@@ -124,34 +112,39 @@ runs:
       run: |
         echo "::group::Installing ResoniteHotReloadLib"
 
-        $hotReloadVersion = "${{ inputs.hot-reload-version }}"
+        # Fixed to v3.0.0-RML version
+        $hotReloadVersion = "v3.0.0-RML"
         $baseUrl = "https://github.com/Nytra/ResoniteHotReloadLib/releases"
-
-        if ($hotReloadVersion -eq "latest") {
-          # Get the latest release tag
-          $latestRelease = Invoke-RestMethod -Uri "$baseUrl/latest" -Headers @{ "Accept" = "application/vnd.github.v3+json" }
-          $hotReloadVersion = $latestRelease.tag_name
-          echo "Latest ResoniteHotReloadLib version: $hotReloadVersion"
-        }
-
         $downloadUrl = "$baseUrl/download/$hotReloadVersion"
         $rmlLibsPath = "${{ steps.setup-paths.outputs.rml-libs-path }}"
 
         # Download ResoniteHotReloadLib.dll
         $hotReloadDllPath = Join-Path $rmlLibsPath "ResoniteHotReloadLib.dll"
-        echo "Downloading ResoniteHotReloadLib.dll..."
-        Invoke-WebRequest -Uri "$downloadUrl/ResoniteHotReloadLib.dll" -OutFile $hotReloadDllPath
+        $mainDllUrl = "$downloadUrl/ResoniteHotReloadLib.dll"
+        echo "Downloading ResoniteHotReloadLib.dll from: $mainDllUrl"
 
-        # Check if this version has Core.dll (v3.0.0-RML and later)
-        if ($hotReloadVersion -like "*-RML*" -or ($hotReloadVersion -match "v?(\d+)\.(\d+)\.(\d+)" -and [version]"$($Matches[1]).$($Matches[2]).$($Matches[3])" -ge [version]"3.0.0")) {
-          $hotReloadCoreDllPath = Join-Path $rmlLibsPath "ResoniteHotReloadLibCore.dll"
-          echo "Downloading ResoniteHotReloadLibCore.dll..."
-          try {
-            Invoke-WebRequest -Uri "$downloadUrl/ResoniteHotReloadLibCore.dll" -OutFile $hotReloadCoreDllPath
-            echo "✓ ResoniteHotReloadLibCore.dll downloaded"
-          } catch {
-            echo "::warning::ResoniteHotReloadLibCore.dll not found for version $hotReloadVersion, skipping..."
+        try {
+          Invoke-WebRequest -Uri $mainDllUrl -OutFile $hotReloadDllPath -ErrorAction Stop
+          echo "✓ ResoniteHotReloadLib.dll downloaded successfully"
+        } catch {
+          echo "::error::Failed to download ResoniteHotReloadLib.dll from $mainDllUrl"
+          echo "::error::Error: $($_.Exception.Message)"
+          if ($_.Exception.Response) {
+            echo "::error::HTTP Status: $($_.Exception.Response.StatusCode)"
           }
+          throw
+        }
+
+        # Try to download ResoniteHotReloadLibCore.dll (optional for newer versions)
+        $hotReloadCoreDllPath = Join-Path $rmlLibsPath "ResoniteHotReloadLibCore.dll"
+        $coreDllUrl = "$downloadUrl/ResoniteHotReloadLibCore.dll"
+        echo "Attempting to download ResoniteHotReloadLibCore.dll from: $coreDllUrl"
+        try {
+          Invoke-WebRequest -Uri $coreDllUrl -OutFile $hotReloadCoreDllPath -ErrorAction Stop
+          echo "✓ ResoniteHotReloadLibCore.dll downloaded successfully"
+        } catch {
+          echo "::warning::ResoniteHotReloadLibCore.dll not found for version $hotReloadVersion"
+          echo "::warning::This is optional and may not be available for all versions. Continuing..."
         }
 
         echo "::notice::ResoniteHotReloadLib $hotReloadVersion installed successfully"


### PR DESCRIPTION
fix: 🐛 Update default hot-reload version to v3.0.0-RML and improve download error handling

fix: 🐛 Update hot-reload version to 2.1.1 in build workflow